### PR TITLE
Create PromptEng.md

### DIFF
--- a/PromptEng.md
+++ b/PromptEng.md
@@ -1,0 +1,13 @@
+Prompt engineering is the process of crafting clear instructions to guide AI systems, like GitHub Copilot, to generate context-appropriate code tailored to your project's specific needs. This ensures the code is syntactically, functionally, and contextually correct.
+
+## Principles of prompt engineering
+
+- **Single**: Always focus your prompt on a single, well-defined task or question. This clarity is crucial for eliciting accurate and useful responses from Copilot.
+- **Specific**: Ensure that your instructions are explicit and detailed. Specificity leads to more applicable and precise code suggestions.
+- **Short**: While being specific, keep prompts concise and to the point. This balance ensures clarity without overloading Copilot or complicating the interaction.
+- **Surround**: Utilize descriptive filenames and keep related files open. This provides Copilot with rich context, leading to more tailored code suggestions.
+
+By adding some comments at the top of your code to give more details to what you want, you can give more context to Copilot to understand your prompt, and provide better code suggestions.
+
+![context example](https://github.com/codess-aus/GitHub-Copilot-Certification/blob/799ac0f6224a736a02b9ebee0021021d727aeebf/images/context.gif)
+


### PR DESCRIPTION
This pull request includes a new section in the `PromptEng.md` file that provides an introduction to prompt engineering and outlines key principles to follow for effective prompt creation.

Documentation improvements:

* [`PromptEng.md`](diffhunk://#diff-3ddf5e8240a9b619aefb6603e5721d2d6f9f1113640ae2e35c89c30496d34913R1-R13): Added a detailed explanation of prompt engineering, including its importance and principles such as focusing on a single task, being specific, keeping prompts short, and utilizing context. Additionally, included an example image to illustrate the concept.