### PR TITLE
Update commit-and-pr.yml

### DIFF
--- a/.github/workflows/commit-and-pr.yml
+++ b/.github/workflows/commit-and-pr.yml
@@ -25,7 +25,9 @@ jobs:
 
       - name: Make changes
         run: |
-          echo "Automated commit for $(date)" > commit.txt
+          DAY=$(date +%d) # Get the day of the month
+          FILE="commit$(( DAY % 4 + 1 )).txt" # Cycle through commit1.txt, commit2.txt, commit3.txt, commit4.txt
+          cp $FILE commit.txt
           git add commit.txt
 
       - name: Commit changes


### PR DESCRIPTION
This pull request includes a change to the `jobs` section in the `.github/workflows/commit-and-pr.yml` file. The change improves the commit message generation by cycling through different commit files based on the day of the month.

* [`.github/workflows/commit-and-pr.yml`](diffhunk://#diff-88d946e908fe7e7f501e72895da23d408c16df2311e2ef2f33b1dc0f20ae85b7L28-R30): Modified the script to cycle through `commit1.txt`, `commit2.txt`, `commit3.txt`, and `commit4.txt` based on the day of the month, instead of using a static commit message.