### PR TITLE
Update commit-and-pr.yml

### DIFF
--- a/.github/workflows/commit-and-pr.yml
+++ b/.github/workflows/commit-and-pr.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Make changes
         run: |
           DAY=$(date +%d) # Get the day of the month
-          FILE="commit$(( DAY % 4 + 1 )).txt" # Cycle through commit1.txt, commit2.txt, commit3.txt, commit4.txt
-          cp $FILE commit.txt
-          git add commit.txt
+          FILE="copilot$(( DAY % 4 + 1 )).md" # Cycle through copilot1.md, copilot2.md, copilot3.md, copilot4.md
+          cp $FILE commit.md
+          git add commit.md
 
       - name: Commit changes
         run: |


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/commit-and-pr.yml` file to update the file naming convention used in the workflow.

Workflow file update:

* [`.github/workflows/commit-and-pr.yml`](diffhunk://#diff-88d946e908fe7e7f501e72895da23d408c16df2311e2ef2f33b1dc0f20ae85b7L29-R31): Changed the file naming convention from `commitX.txt` to `copilotX.md` and updated the corresponding file operations to reflect this new naming convention.